### PR TITLE
Fix undefined selectedOption

### DIFF
--- a/src/components/QuizQuestion.tsx
+++ b/src/components/QuizQuestion.tsx
@@ -26,7 +26,9 @@ const QuizQuestion: React.FC<QuizQuestionProps> = ({
         </h3>
         
         <RadioGroup
-          value={selectedOption !== null ? selectedOption.toString() : undefined}
+          value={
+            selectedOption != null ? selectedOption.toString() : undefined
+          }
           className="space-y-3"
           onValueChange={(value) => onSelectOption(parseInt(value))}
         >

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -25,7 +25,7 @@ const QuizPage = () => {
   const quiz = sampleQuizzes.find(q => q.id === quizId);
   
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
-  const [answers, setAnswers] = useState<number[]>([]);
+  const [answers, setAnswers] = useState<(number | null)[]>([]);
   const [quizCompleted, setQuizCompleted] = useState(false);
   const [showResults, setShowResults] = useState(false);
   const [timeTaken, setTimeTaken] = useState(0);
@@ -90,7 +90,7 @@ const QuizPage = () => {
   
   const currentQuestion = quiz.questions[currentQuestionIndex];
   const isLastQuestion = currentQuestionIndex === quiz.questions.length - 1;
-  const selectedOption = answers[currentQuestionIndex];
+  const selectedOption = answers[currentQuestionIndex] ?? null;
   
   // Count answered questions
   const answeredCount = answers.filter(answer => answer !== null).length;
@@ -179,9 +179,9 @@ const QuizPage = () => {
               </Button>
             </div>
             
-            <QuizQuestion 
+            <QuizQuestion
               question={currentQuestion}
-              selectedOption={answers[currentQuestionIndex]}
+              selectedOption={answers[currentQuestionIndex] ?? null}
               onSelectOption={handleSelectOption}
               showResults={true}
             />


### PR DESCRIPTION
## Summary
- handle undefined `selectedOption` in `<QuizQuestion>`
- initialize answers state with `(number | null)[]` and pass fallback value in `<QuizPage>`

## Testing
- `npm run lint` *(fails: parsing errors)*